### PR TITLE
feat: Add retry and validation hint support

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@l1m/api",
       "version": "1.0.0",
       "dependencies": {
-        "@l1m/core": "^0.1.1",
+        "@l1m/core": "^0.1.3",
         "@ts-rest/fastify": "^3.52.0",
         "@types/ioredis": "^4.28.10",
         "fastify": "^4.26.1",
@@ -1839,11 +1839,12 @@
       }
     },
     "node_modules/@l1m/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@l1m/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-PdahPcDpuWg5hw904cyBl5XHxKWQfEU6zG2Qi9yT9hbQ4qNrmGh7gOH4KVyzn3XYZfShYRGu7+WZXJOtt40+sw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@l1m/core/-/core-0.1.3.tgz",
+      "integrity": "sha512-+FGuifoZZKVg2idu8xQJh9/FSxsIHRE0N4datgPI2pzbSKMIPbLp4tlSDL4jFaAEYPadFgnQy7Xtp85Oil6oiw==",
       "dependencies": {
         "ajv": "^8.17.1",
+        "async-retry": "^1.3.3",
         "dereference-json-schema": "^0.2.1",
         "jsonschema": "^1.5.0",
         "mimetics": "^1.0.4",
@@ -2217,6 +2218,15 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5769,6 +5779,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "main": "dist/server.js",
   "private": true,
   "dependencies": {
-    "@l1m/core": "^0.1.1",
+    "@l1m/core": "^0.1.3",
     "@ts-rest/fastify": "^3.52.0",
     "@types/ioredis": "^4.28.10",
     "fastify": "^4.26.1",

--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -36,6 +36,7 @@ export const apiContract = c.router({
       "x-provider-model": z.string(),
       "x-provider-url": z.string(),
       "x-provider-key": z.string(),
+      "x-max-attempts": z.string().optional().default("1"),
       "x-cache-ttl": z.string().optional(),
     }),
     responses: {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -37,6 +37,8 @@ const router = s.router(apiContract, {
     const providerModel = headers["x-provider-model"];
     const providerUrl = headers["x-provider-url"];
 
+    const maxAttempts = headers["x-max-attempts"] ?? 1;
+
     const { input, instruction } = body;
     let { schema } = body;
 
@@ -124,18 +126,23 @@ const router = s.router(apiContract, {
           valid: true,
           raw: undefined,
           errors: undefined,
+          attempts: 1,
         } :
         await structured({
           input,
           type,
           schema,
           instruction,
+          maxAttempts: maxAttempts ? parseInt(maxAttempts) : undefined,
           provider: {
             url: providerUrl,
             key: providerKey,
             model: providerModel,
           },
         });
+
+
+      reply.header("x-attempts", result.attempts);
 
       if (!result.valid) {
         return {

--- a/api/src/test/structured.integration.test.ts
+++ b/api/src/test/structured.integration.test.ts
@@ -130,6 +130,7 @@ describe("Structured Data Extraction API", () => {
     expect(result.data.address.street).toBe("123 Innovation Way");
     expect(Array.isArray(result.data.engineeringTeams)).toBeTruthy();
     expect(result.data.engineeringTeams.length).toBe(3);
+    expect(response.headers.get("x-attempts")).toBe("1");
   });
 
   test("handles base64 encoded JSON correctly", async () => {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@l1m/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@l1m/core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "ajv": "^8.17.1",
+        "async-retry": "^1.3.3",
         "dereference-json-schema": "^0.2.1",
         "jsonschema": "^1.5.0",
         "mimetics": "^1.0.4",
@@ -16,6 +17,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@types/async-retry": "^1.4.9",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.11.24",
         "dotenv": "^16.4.7",
@@ -1477,6 +1479,16 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@types/async-retry": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.9.tgz",
+      "integrity": "sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1589,6 +1601,13 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -1744,6 +1763,15 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4794,6 +4822,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/safe-buffer": {

--- a/core/package.json
+++ b/core/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@l1m/core",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
     "ajv": "^8.17.1",
+    "async-retry": "^1.3.3",
     "dereference-json-schema": "^0.2.1",
     "jsonschema": "^1.5.0",
     "mimetics": "^1.0.4",
@@ -12,6 +13,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/async-retry": "^1.4.9",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.11.24",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
Add the ability to specify `x-max-retries` which will retry requests and feed any validation results back into the chat state.